### PR TITLE
fix stats on track page on small devices closes #14

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -6,3 +6,23 @@
 .basic-btn {
   @apply m-3 rounded bg-blue-500 px-3 py-1.5 text-white hover:bg-blue-700 disabled:bg-gray-700 disabled:hover:bg-gray-700;
 }
+
+@media only screen and (max-width: 500px) {
+  .self-center,
+  .self-center .stats {
+    width: 100%;
+    font-size: 0.9rem;
+  }
+  .self-center .stats .stat {
+    padding: 0.6rem 0.5rem;
+  }
+
+  .self-center .stats .stat .stat-value {
+    font-size: 1.6rem;
+    font-weight: 700;
+  }
+
+  .latest-tasks-timerange {
+    font-size: smaller;
+  }
+}

--- a/src/pages/TrackPage.tsx
+++ b/src/pages/TrackPage.tsx
@@ -161,7 +161,7 @@ export function TrackPage() {
         <div className="mx-2 mt-2 flex items-center">
           <h2 className="text-lg font-medium">Last Tasks</h2>
           <div className="flex-grow"></div>
-          <div className="flex">
+          <div className="latest-tasks-timerange flex">
             {timeRanges.map((range, index, array) => {
               let border =
                 array.length - 1 === index


### PR DESCRIPTION
Before:
<img width="379" alt="Bildschirmfoto 2023-07-05 um 22 49 13" src="https://github.com/webxdc/timetracking-webxdc/assets/18725968/3fe21855-eacf-4727-8d5b-4af40f2af43a">
After:
<img width="379" alt="Bildschirmfoto 2023-07-05 um 22 48 55" src="https://github.com/webxdc/timetracking-webxdc/assets/18725968/45c42b41-4560-4b6e-bede-5e8ae0596adf">

fixes stats (closes #14) and adapt timeframe switcher for the quick task selector on smaller/mobile screens.