### PR TITLE
add option to hide stats summary on track page

### DIFF
--- a/src/pages/MorePage.tsx
+++ b/src/pages/MorePage.tsx
@@ -26,6 +26,14 @@ export function MorePage() {
     internal_set_autocomplete(value);
   };
 
+  const [hide_track_page_stats, internal_set_hide_track_page_stats] = useState(
+    localStorage.getItem("hide_track_page_stats") === "true"
+  );
+  const setHideTrackPageStats = (value: boolean) => {
+    localStorage.setItem("hide_track_page_stats", String(value));
+    internal_set_hide_track_page_stats(value);
+  };
+
   const importFiles = async (format: "BotFormat" | "AppFormat") => {
     let files = await window.webxdc.importFiles({
       extensions: [".json"],
@@ -121,6 +129,14 @@ export function MorePage() {
           type="checkbox"
           checked={auto_complete}
           onChange={() => setAutoComplete(!auto_complete)}
+        />
+      </label>
+      <label className="label cursor-pointer">
+        <span className="label-text">Hide Stats Summary on Track Page</span>
+        <input
+          type="checkbox"
+          checked={hide_track_page_stats}
+          onChange={() => setHideTrackPageStats(!hide_track_page_stats)}
         />
       </label>
       <h1 className="text-xl">Import / Export</h1>

--- a/src/pages/TrackPage.tsx
+++ b/src/pages/TrackPage.tsx
@@ -111,6 +111,8 @@ export function TrackPage() {
     open_entries[open_entries.length - 1];
   const labelRef = useRef<HTMLInputElement>(null);
   const auto_complete = localStorage.getItem("autocomplete_enabled") === "true";
+  const hide_track_page_stats =
+    localStorage.getItem("hide_track_page_stats") === "true";
   const [failedToEndEntry, setFailedToEndEntry] = useState<TaskEntry | null>(
     null
   );
@@ -154,9 +156,11 @@ export function TrackPage() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="self-center">
-        <QuickStats />
-      </div>
+      {!hide_track_page_stats && (
+        <div className="self-center">
+          <QuickStats />
+        </div>
+      )}
       <div className="flex grow flex-col overflow-hidden">
         <div className="mx-2 mt-2 flex items-center">
           <h2 className="text-lg font-medium">Last Tasks</h2>


### PR DESCRIPTION
<img width="369" alt="Bildschirmfoto 2023-07-05 um 23 13 24" src="https://github.com/webxdc/timetracking-webxdc/assets/18725968/d8cfcb64-bf7c-42e7-87b5-0eabee6f4199">
<img width="318" alt="Bildschirmfoto 2023-07-05 um 23 14 17" src="https://github.com/webxdc/timetracking-webxdc/assets/18725968/cea25456-34ea-4718-950b-509add822e32">
