### PR TITLE
refine/fix xdc metadata

### DIFF
--- a/public/manifest.toml
+++ b/public/manifest.toml
@@ -1,5 +1,3 @@
-name = "TimeTracking 🕰️"
-description = "Track and analyze your project-/work-times easialy across multiple devices  with this webxdc app."
-
-version = 1
+name = "TimeTracking"
+description = "Track and analyze your project-/work-times."
 source_code_url = "https://github.com/webxdc/timetracking-webxdc"


### PR DESCRIPTION
- remove superflous version field
- simplify description 

Let's not talk about "multi-device" etc. -- this is true for almost all webxdc apps. 
