### PR TITLE
add more Statistics

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - fix typo in "why is my month missing" dialog
 - fix weird sidewards overscrolling bug in statistics/weekPage
+- add "Time spend by task" to Statistics
 
 ## 0.5.0
 

--- a/src/components/StatsTaskDistribution.tsx
+++ b/src/components/StatsTaskDistribution.tsx
@@ -1,0 +1,107 @@
+import { DateTime, Duration } from "luxon";
+import { useStore } from "../store";
+
+export function TaskDistributionPie() {
+  const timeRange: [start: number, end: number] = [
+    0,
+    DateTime.now().toMillis(),
+  ];
+
+  const time_spent_by_label = useStore
+    .getState()
+    .getTimeSpendByLabel(...timeRange);
+
+  const time_spent_total = time_spent_by_label.reduce(
+    (p, c) => p + c.timeSpend.toMillis(),
+    0
+  );
+
+  const rawLabels: {
+    label: string;
+    timeSpend: Duration;
+    percentage: number;
+  }[] = [];
+  const threshold = 0.01;
+  let time_for_other_label = 0;
+  for (const label of time_spent_by_label) {
+    const timeSpend = label.timeSpend.toMillis();
+    const percentage = timeSpend / time_spent_total;
+    if (percentage <= threshold) {
+      time_for_other_label += timeSpend;
+    } else {
+      rawLabels.push({
+        ...label,
+        percentage,
+      });
+    }
+  }
+  rawLabels.sort((a, b) => b.percentage - a.percentage);
+
+  let cursor = 0;
+  const labelsSortedWithPercentage: {
+    label: string;
+    timeSpend: Duration;
+    percentage: number;
+    start: number;
+    end: number;
+  }[] = [];
+
+  for (const label of rawLabels) {
+    labelsSortedWithPercentage.push({
+      ...label,
+      start: cursor,
+      end: (cursor = cursor + label.percentage),
+    });
+  }
+
+  if (time_for_other_label !== 0) {
+    labelsSortedWithPercentage.push({
+      label: "Other Tasks",
+      percentage: time_for_other_label / time_spent_total,
+      timeSpend: Duration.fromMillis(time_for_other_label),
+      start: cursor,
+      end: 1,
+    });
+  }
+
+  return (
+    <div>
+      <table className="charts-css pie max-w-md w-2/4">
+        <tbody>
+          {labelsSortedWithPercentage.map((label) => (
+            <tr>
+              <td
+                key={btoa(label.label) + "-" + label.percentage}
+                style={{ "--start": label.start, "--end": label.end }}
+              >
+                <span className="data"></span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <ul className="charts-css legend legend-square mt-2">
+        {labelsSortedWithPercentage.map((label) => (
+          <li
+            className="w-full flex"
+            key={btoa(label.label) + "-" + label.percentage}
+          >
+            <span className="flex-grow">
+              {label.label}: (
+              {label.timeSpend
+                .shiftTo("hours", "minutes", "milliseconds")
+                .set({ milliseconds: 0 })
+                .shiftTo("hours", "minutes")
+                .toHuman({ unitDisplay: "short" })}
+              )
+            </span>
+
+            <span className="float-right">
+              {Math.round(label.percentage * 10000) / 100}%
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/TrackPageStats.tsx
+++ b/src/components/TrackPageStats.tsx
@@ -91,7 +91,7 @@ export function QuickStats() {
   }, [entries]); // update when entries change
 
   return (
-    <div className="stats shadow">
+    <div className="stats shadow" style={{ minHeight: 110 }}>
       {stats && (
         <>
           <div className="stat">

--- a/src/pages/StatisticsPage.tsx
+++ b/src/pages/StatisticsPage.tsx
@@ -46,6 +46,36 @@ export function StatisticsPage() {
     { label: "Month", value: "month" },
   ];
 
+  type TimeRange = [start: number, end: number];
+  const [pieTimeRangeIndex, setPieTimeRangeIndex] = useState<number>(0);
+  const pieTimeRangeOptions: {
+    label: string;
+    value: TimeRange;
+    threshold?: number;
+  }[] = [
+    {
+      label: "Current Week",
+      value: [now.startOf("week").toMillis(), now.toMillis()],
+      threshold: 0.01,
+    },
+    {
+      label: "Last Week",
+      value: [
+        now.startOf("week").minus({ week: 1 }).toMillis(),
+        now.startOf("week").toMillis(),
+      ],
+    },
+    {
+      label: "This Month",
+      value: [now.startOf("month").toMillis(), now.toMillis()],
+    },
+    {
+      label: "This Year",
+      value: [now.startOf("year").toMillis(), now.toMillis()],
+    },
+    { label: "Everything", value: [0, now.toMillis()] },
+  ];
+
   return (
     <div className="flex flex-col">
       <h1 className="p-1 text-center text-lg font-medium">Stats</h1>
@@ -112,8 +142,38 @@ export function StatisticsPage() {
       <div className="divider">Current Year</div>
       <ActivityMap />
       <div className="divider">Time spend by Task</div>
-      in total (todo possibility to change timeframe)
-      <TaskDistributionPie />
+
+      <div className="my-2 flex w-full justify-center">
+        <div className="latest-tasks-timerange flex">
+          {pieTimeRangeOptions.map((mode, index, array) => {
+            let border =
+              array.length - 1 === index
+                ? "rounded-r-lg border-l-0"
+                : index === 0
+                ? "rounded-l-lg border-r-0"
+                : "border-x-0";
+
+            let active =
+              pieTimeRangeIndex === index
+                ? "bg-slate-600 hover:bg-slate-600 text-white"
+                : "";
+
+            return (
+              <button
+                key={index}
+                onClick={() => setPieTimeRangeIndex(index)}
+                className={`pv-2 border-collapse border-2 border-solid border-slate-300 px-2 py-1 font-medium hover:bg-slate-500 hover:text-white ${border} ${active}`}
+              >
+                {mode.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <TaskDistributionPie
+        timeRange={pieTimeRangeOptions[pieTimeRangeIndex].value}
+        threshold={pieTimeRangeOptions[pieTimeRangeIndex].threshold}
+      />
     </div>
   );
 }

--- a/src/pages/StatisticsPage.tsx
+++ b/src/pages/StatisticsPage.tsx
@@ -25,6 +25,7 @@ import { NavigationContext } from "../App";
 import { WeekView } from "../components/StatsWeekView";
 import { QuickStats } from "../components/TrackPageStats";
 import { MonthView } from "../components/StatsMonthViewDays";
+import { TaskDistributionPie } from "../components/StatsTaskDistribution";
 
 export function StatisticsPage() {
   const now = DateTime.now();
@@ -110,6 +111,9 @@ export function StatisticsPage() {
       </div>
       <div className="divider">Current Year</div>
       <ActivityMap />
+      <div className="divider">Time spend by Task</div>
+      in total (todo possibility to change timeframe)
+      <TaskDistributionPie />
     </div>
   );
 }

--- a/src/pages/StatisticsPage.tsx
+++ b/src/pages/StatisticsPage.tsx
@@ -54,7 +54,7 @@ export function StatisticsPage() {
     threshold?: number;
   }[] = [
     {
-      label: "Current Week",
+      label: "This Week",
       value: [now.startOf("week").toMillis(), now.toMillis()],
       threshold: 0.01,
     },
@@ -73,7 +73,7 @@ export function StatisticsPage() {
       label: "This Year",
       value: [now.startOf("year").toMillis(), now.toMillis()],
     },
-    { label: "Everything", value: [0, now.toMillis()] },
+    // { label: "Everything", value: [0, now.toMillis()] },
   ];
 
   return (


### PR DESCRIPTION
- avoid content jumping around
- add Time spend by Task
- add time frame selection
- update changelog
- remove everything option because it does not fit on smaller screens

<img width="380" alt="Bildschirmfoto 2023-10-19 um 23 02 43" src="https://github.com/webxdc/timetracking-webxdc/assets/18725968/269b0f0a-a2a0-4f5c-ba63-2435950e6b7a">
